### PR TITLE
Update aws-cdk from 2.174.0 to 2.175.1

### DIFF
--- a/infra-ts/package-lock.json
+++ b/infra-ts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "infra",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.174.0",
+        "aws-cdk-lib": "2.175.1",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
       },
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "22.7.9",
-        "aws-cdk": "2.174.0",
+        "aws-cdk": "2.175.1",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
@@ -1261,9 +1261,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.174.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.174.0.tgz",
-      "integrity": "sha512-RN9Y/+MBht0xBwFVKSOwEGBSf/8Q31zwZmRkH9psWHpW24NbB9/frICRqIiWFqiedlNdLdjYkcwP2U4V6Ud6AQ==",
+      "version": "2.175.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.175.1.tgz",
+      "integrity": "sha512-duvy0FtGAAYqJi/x0MjBfCp60ZlDYl0X5/GrADwMz4AfHQ8aTXCyaVsdJuCxz0ZMHSNaFRuCNkAlc2Xu43zQmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1277,9 +1277,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.174.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.174.0.tgz",
-      "integrity": "sha512-OHBJcsg0i4KftWVeUzw1AkG7onZWNNM/DH7NQnbDOs0Ap716VvtcTUubUpeFrazDWe9Opfn1essTjv6gaVyHBw==",
+      "version": "2.175.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.175.1.tgz",
+      "integrity": "sha512-2OiZDUeuAA5nBrWKxQVT0CHrQmLLx7SIpUeqyKRLEdiYPFlj3nCd/0KcVpsy6hPKS+IZp7Qm1kghmGMsV6JGoA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",

--- a/infra-ts/package.json
+++ b/infra-ts/package.json
@@ -22,12 +22,12 @@
     "@types/node": "22.7.9",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
-    "aws-cdk": "2.174.0",
+    "aws-cdk": "2.175.1",
     "ts-node": "^10.9.2",
     "typescript": "~5.6.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.174.0",
+    "aws-cdk-lib": "2.175.1",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION

## [v2.175.1](https://github.com/aws/aws-cdk/releases/tag/v2.175.1)
### Bug Fixes
- cli: "no stack found in the main cloud assembly" (https://github.com/aws/aws-cdk/issues/32839) ([7b68908](https://github.com/aws/aws-cdk/commit/7b68908dbebde02037d8b7650f4bb10d4c5db89d)), closes https://github.com/aws/aws-cdk/issues/32636 https://github.com/aws/aws-cdk/issues/32836 https://github.com/aws/aws-cdk/issues/32836

## [v2.175.0](https://github.com/aws/aws-cdk/releases/tag/v2.175.0)
### Features
- ecs: enable fault injection flag (https://github.com/aws/aws-cdk/issues/32598) ([ed366ce](https://github.com/aws/aws-cdk/commit/ed366ce812a94066de04e9862d6cbd1083bf5d9c))
- ecs: warning when creating a service with the default minHealthyPercent (https://github.com/aws/aws-cdk/issues/31738) ([3606deb](https://github.com/aws/aws-cdk/commit/3606deb5b519365d846e6e66406c835889827055)), closes https://github.com/aws/aws-cdk/issues/31705
- update L1 CloudFormation resource definitions (https://github.com/aws/aws-cdk/issues/32768) ([107eed3](https://github.com/aws/aws-cdk/commit/107eed3b50e86246da03d6b59197452e2af0bfaf))
- cli: warn of non-existent stacks in cdk destroy (https://github.com/aws/aws-cdk/issues/32636) ([c199378](https://github.com/aws/aws-cdk/commit/c199378667cb63ffe8636dda6b6316dcc6eb47e9)), closes https://github.com/aws/aws-cdk/issues/32545 https://github.com/aws/aws-cdk/issues/27179 [40aws-cdk-testing/cli-integ/tests/cli-integ-tests/cli.integtest.ts#L190](https://github.com/40aws-cdk-testing/cli-integ/tests/cli-integ-tests/cli.integtest.ts/issues/L190) [aws-cdk-testing/cli-integ/tests/cli-integ-tests/cli.integtest.ts#L286-L291](https://github.com/aws-cdk-testing/cli-integ/tests/cli-integ-tests/cli.integtest.ts/issues/L286-L291)
- eks: update nodegroup gpu check (https://github.com/aws/aws-cdk/issues/32715) ([693afea](https://github.com/aws/aws-cdk/commit/693afea86310fd444d237b9f70204fbf4bb5a68d)), closes https://github.com/aws/aws-cdk/issues/31347
- update L1 CloudFormation resource definitions (https://github.com/aws/aws-cdk/issues/32755) ([8f97112](https://github.com/aws/aws-cdk/commit/8f97112c89c6b39e299b0cd437336bab11cfdaf8))
- kms: add sign and verify related grant methods (https://github.com/aws/aws-cdk/issues/32681) ([86d2853](https://github.com/aws/aws-cdk/commit/86d2853a9a919669694a2448805a092839a7f4db)), closes https://github.com/aws/aws-cdk/issues/23185

### Bug Fixes
- cli: cannot set environment variable CI=false (https://github.com/aws/aws-cdk/issues/32749) ([26b361d](https://github.com/aws/aws-cdk/commit/26b361de357a3b83c59dc4931d4797328d220534))
- cli: requiresRefresh function does not respect null (https://github.com/aws/aws-cdk/issues/32666) ([2abc23c](https://github.com/aws/aws-cdk/commit/2abc23c4cfdf27e8623fea3d3fbb71ad7e25dbbe)), closes https://github.com/aws/aws-cdk/issues/32653 [/github.com/smithy-lang/smithy-typescript/blob/main/packages/property-provider/src/memoize.ts#L27](https://github.com/aws//github.com/smithy-lang/smithy-typescript/blob/main/packages/property-provider/src/memoize.ts/issues/L27)
- cloudwatch: render region and accountId when directly set on metrics (https://github.com/aws/aws-cdk/issues/32325) ([c393481](https://github.com/aws/aws-cdk/commit/c3934817ea15bb3187f67112a1d56c13aa555524)), closes https://github.com/aws/aws-cdk/issues/28731
- ecs: outdated linux commands for canContainersAccessInstanceRole=false and also deprecate property (https://github.com/aws/aws-cdk/issues/32763) ([bbdd42c](https://github.com/aws/aws-cdk/commit/bbdd42c8f45916d5c6945f3429916f6199d2ec66)), closes https://github.com/aws/aws-cdk/issues/28518
## Alpha modules (2.175.0-alpha.0)
### Features
- s3objectlambda: open s3 access point arn (https://github.com/aws/aws-cdk/issues/32661) ([0486b9c](https://github.com/aws/aws-cdk/commit/0486b9c5e2b4286499a9d3f87a0db7c95741fb6b)), closes https://github.com/aws/aws-cdk/issues/31950
### Bug Fixes
- apprunner: the Service class does not implement IService (https://github.com/aws/aws-cdk/issues/32771) ([3d56efa](https://github.com/aws/aws-cdk/commit/3d56efa20ef92761ed22f12e4f651856b6889be3)), closes https://github.com/aws/aws-cdk/issues/32745
- integ-runner: ENOENT no such file or directory 'recommended-feature-flags.json' (https://github.com/aws/aws-cdk/issues/32750) ([f809b94](https://github.com/aws/aws-cdk/commit/f809b94d9952b8203221e73e177d2615c21248a8))